### PR TITLE
Update README.md with bootstrap dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ add to application.js and application.css something like
 
     //= require bootstrap-select
 
+Also, you must require at least the *alert* and *dropdown* bootstrap components.
+For example, if using
+[bootstrap-sass-rails](https://github.com/yabawock/bootstrap-sass-rails):
+
+    //= require twitter/bootstrap/alert
+    //= require twitter/bootstrap/dropdown
 
 ## Installation
 


### PR DESCRIPTION
_bootstrap-select_ depends on these bootstrap components: `alert` and `dropdown`.
For those not including everything from bootstrap, it would be nice to add
these hidden dependencies to the readme.

I didn't add this issue to bootstrap-select repo because I think picking
specific components it's more related with the asset pipeline.
